### PR TITLE
Add CTR improvement workflow

### DIFF
--- a/atami/src/mastra/agents/analyticsAdvisorAgent.ts
+++ b/atami/src/mastra/agents/analyticsAdvisorAgent.ts
@@ -1,0 +1,15 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { Agent } from '@mastra/core/agent';
+
+/**
+ * CTR 改善提案に特化したアナリティクスアドバイザーエージェント
+ */
+export const analyticsAdvisorAgent = new Agent({
+  name: 'YouTube Analytics Advisor',
+  instructions: `
+    あなたはYouTube動画のパフォーマンス改善を提案するマーケティングアドバイザーです。
+    提供された指標(CTR、インプレッション数、平均視聴維持時間など)を基に、
+    CTR が低い原因を推定し、タイトル改善案を日本語で3つ提案してください。
+  `,
+  model: anthropic('claude-3-7-sonnet-20250219')
+});

--- a/atami/src/mastra/agents/index.ts
+++ b/atami/src/mastra/agents/index.ts
@@ -42,6 +42,7 @@ export { channelConceptAgent } from './channelConceptAgent';
 export { youtubeThumbnailTitleGeneratorAgent } from './thumbnailTitleGeneratorAgent';
 export { youtubeVideoPlanningAgent } from './videoPlanningAgent';
 export { keywordResearchAgent } from './keywordResearchAgent';
+export { analyticsAdvisorAgent } from './analyticsAdvisorAgent';
 
 export const youtubeChannelPlannerAgent = new Agent({
   name: 'YouTube Channel Planning Agent',

--- a/atami/src/mastra/index.ts
+++ b/atami/src/mastra/index.ts
@@ -17,7 +17,8 @@ import {
   youtubeVideoPlanningWorkflow,
   keywordResearchWorkflow,
   youtubeChannelConceptDesignWorkflow,
-  youtubeKeywordStrategyWorkflow
+  youtubeKeywordStrategyWorkflow,
+  youtubeCtrGapImprovementWorkflow
 } from './workflows';
 import {
   youtubeAgent,
@@ -28,7 +29,8 @@ import {
   channelConceptAgent,
   youtubeThumbnailTitleGeneratorAgent,
   youtubeVideoPlanningAgent,
-  keywordResearchAgent
+  keywordResearchAgent,
+  analyticsAdvisorAgent
 } from './agents';
 
 export const mastra = new Mastra({
@@ -39,10 +41,11 @@ export const mastra = new Mastra({
     inputCollectionWorkflow,
     youtubeChannelConceptWorkflow,
     youtubeThumbnailTitleGeneratorWorkflow,
-    youtubeVideoPlanningWorkflow,
-    keywordResearchWorkflow,
-    youtubeChannelConceptDesignWorkflow,
-    youtubeKeywordStrategyWorkflow
+  youtubeVideoPlanningWorkflow,
+  keywordResearchWorkflow,
+  youtubeChannelConceptDesignWorkflow,
+    youtubeKeywordStrategyWorkflow,
+    youtubeCtrGapImprovementWorkflow
   },
   agents: {
     youtubeAgent,
@@ -53,7 +56,8 @@ export const mastra = new Mastra({
     channelConceptAgent,
     youtubeThumbnailTitleGeneratorAgent,
     youtubeVideoPlanningAgent,
-    keywordResearchAgent
+    keywordResearchAgent,
+    analyticsAdvisorAgent
   },
   storage: new LibSQLStore({
     // For persistent storage, use file path instead of memory

--- a/atami/src/mastra/workflows/ctrGapImprovementWorkflow.ts
+++ b/atami/src/mastra/workflows/ctrGapImprovementWorkflow.ts
@@ -1,0 +1,83 @@
+import { createStep } from '@mastra/core';
+import { createWorkflow } from '@mastra/core/workflows';
+import { z } from 'zod';
+import { analyticsAdvisorAgent } from '../agents';
+
+// Step1: モックでAnalytics取得
+const fetchAnalytics = createStep({
+  id: 'fetch-analytics',
+  description: '動画のCTRやインプレッションを取得',
+  inputSchema: z.object({
+    video_id: z.string().describe('対象動画のYouTube ID'),
+    category: z.string().optional().describe('ジャンル')
+  }),
+  outputSchema: z.object({
+    ctr: z.number(),
+    impressions: z.number(),
+    avgViewDuration: z.number()
+  }),
+  execute: async () => {
+    return { ctr: 2.8, impressions: 12000, avgViewDuration: 145 };
+  }
+});
+
+// Step2: CTRギャップ診断
+const ctrGapDiagnosis = createStep({
+  id: 'ctr-gap-diagnosis',
+  description: 'CTRが平均と比べてどの程度か判定',
+  inputSchema: z.object({ ctr: z.number(), impressions: z.number() }),
+  outputSchema: z.object({
+    gapLevel: z.enum(['low', 'average', 'good']),
+    reason: z.string()
+  }),
+  execute: async ({ context }) => {
+    const { ctr } = context;
+    if (ctr < 3.0) return { gapLevel: 'low', reason: 'CTRが平均以下です' };
+    if (ctr < 5.0) return { gapLevel: 'average', reason: '平均水準ですが改善の余地あり' };
+    return { gapLevel: 'good', reason: '高いCTRです' };
+  }
+});
+
+// Step3: 改善提案
+const improvementSuggestion = createStep({
+  id: 'improvement-suggestion',
+  description: 'CTR改善のためのタイトル案を提案',
+  inputSchema: z.object({}),
+  outputSchema: z.object({ message: z.string() }),
+  execute: async (params) => {
+    const analytics = params.context?.getStepResult(fetchAnalytics);
+    const gap = params.context?.getStepResult(ctrGapDiagnosis);
+
+    if (!analytics || !gap) {
+      return { message: '十分なデータがありません' };
+    }
+
+    if (gap.gapLevel === 'good') {
+      return { message: '改善の必要はありません' };
+    }
+
+    const prompt = `CTRが${analytics.ctr}%と低いため、動画タイトルの改善案を3つ提案してください。動画ジャンル：${params.context?.input.category ?? ''}`;
+    const res = await analyticsAdvisorAgent.generate([{ role: 'user', content: prompt }]);
+    return { message: res.text };
+  }
+});
+
+export const youtubeCtrGapImprovementWorkflow = createWorkflow({
+  id: 'youtube-ctr-gap-improvement-workflow',
+  description: 'CTRギャップ診断とタイトル改善提案を行うワークフロー',
+  inputSchema: z.object({
+    video_id: z.string().describe('対象動画のYouTube ID'),
+    category: z.string().optional().describe('ジャンル')
+  }),
+  outputSchema: z.object({
+    ctr: z.number(),
+    gapLevel: z.string(),
+    reason: z.string(),
+    message: z.string()
+  })
+})
+  .then(fetchAnalytics)
+  .then(ctrGapDiagnosis)
+  .then(improvementSuggestion);
+
+youtubeCtrGapImprovementWorkflow.commit();

--- a/atami/src/mastra/workflows/index.ts
+++ b/atami/src/mastra/workflows/index.ts
@@ -23,6 +23,7 @@ export { youtubeLongFormConversationWorkflow } from './longFormConversationWorkf
 export { youtubeContentScoringWorkflow } from './contentScoringWorkflow';
 export { youtubeShortsIdeationWorkflow } from './shortsIdeationWorkflow';
 export { youtubeShortsScriptWorkflow } from './shortsScriptWorkflow';
+export { youtubeCtrGapImprovementWorkflow } from './ctrGapImprovementWorkflow';
 
 // ダミーワークフロー（vNext形式で定義）
 const youtubeSearchWorkflow = createWorkflow({

--- a/atami/tests/workflows.test.ts
+++ b/atami/tests/workflows.test.ts
@@ -46,13 +46,23 @@ const youtubeVideoAnalyticsWorkflow = {
   commit: jest.fn()
 };
 
+const youtubeCtrGapImprovementWorkflow = {
+  name: 'youtube-ctr-gap-improvement-workflow',
+  run: jest.fn(),
+  _mastra: null,
+  __registerMastra: jest.fn(),
+  __registerPrimitives: jest.fn(),
+  commit: jest.fn()
+};
+
 // モックをエクスポート
 jest.mock('../src/mastra/workflows/index', () => ({
   youtubeSearchWorkflow,
   youtubeChannelPlannerWorkflow,
   youtubeTitleGeneratorWorkflow,
   youtubeChannelAnalyticsWorkflow,
-  youtubeVideoAnalyticsWorkflow
+  youtubeVideoAnalyticsWorkflow,
+  youtubeCtrGapImprovementWorkflow
 }));
 
 import * as dotenv from 'dotenv';
@@ -223,6 +233,25 @@ describe('YouTube Workflows', () => {
       expect(result).toBeDefined();
       expect(result).toBe(mockResult);
       expect(youtubeVideoAnalyticsWorkflow.run).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('youtubeCtrGapImprovementWorkflow', () => {
+    test('should be properly initialized', () => {
+      expect(youtubeCtrGapImprovementWorkflow).toBeDefined();
+      expect(youtubeCtrGapImprovementWorkflow.name).toBe('youtube-ctr-gap-improvement-workflow');
+      expect(youtubeCtrGapImprovementWorkflow.run).toBeDefined();
+    });
+
+    test('should successfully run the workflow', async () => {
+      const mockResult = { ctr: 2.8, gapLevel: 'low', reason: 'CTRが平均以下です', message: 'sample' };
+      youtubeCtrGapImprovementWorkflow.run.mockResolvedValueOnce(mockResult);
+
+      const result = await youtubeCtrGapImprovementWorkflow.run({ video_id: 'abc', category: '教育' });
+
+      expect(result).toBeDefined();
+      expect(result).toBe(mockResult);
+      expect(youtubeCtrGapImprovementWorkflow.run).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- create `analyticsAdvisorAgent` for improvement suggestions
- add `ctrGapImprovementWorkflow` to diagnose CTR gaps and suggest better titles
- register new agent and workflow with Mastra
- export new workflow in index files
- cover new workflow in tests

## Testing
- `npm test` *(fails: jest not installed)*