### PR TITLE
Update naming conventions throughout the codebase

### DIFF
--- a/atami/docs/naming-conventions.md
+++ b/atami/docs/naming-conventions.md
@@ -1,0 +1,102 @@
+# 命名規則ガイド
+
+このドキュメントは、YouTube Mastraプロジェクトにおけるコード命名規則についてのガイドラインを提供します。一貫性のある命名パターンを使用することで、コードの可読性と保守性を向上させることを目的としています。
+
+## 基本原則
+
+YouTube Mastraプロジェクトでは、以下の基本原則に従った命名規則を採用しています：
+
+1. **プレフィックスの一貫性**: YouTubeに関連するすべてのコンポーネントには `youtube` プレフィックスを使用します
+2. **タイプサフィックス**: コンポーネントのタイプを示すサフィックスを使用します（例: `Agent`, `Tool`, `Workflow`）
+3. **機能名の明確さ**: 機能を明確に表す名前を使用し、略語は避けます
+
+## コンポーネント別の命名規則
+
+### ツール（Tools）
+
+ツールには `youtube{機能名}Tool` の形式を使用します。
+
+**例:**
+- `youtubeTitleGeneratorTool`
+- `youtubeInputCollectionTool`
+- `youtubeSearchTool`
+- `youtubeChannelConceptTool`
+- `youtubeThumbnailTitleGeneratorTool`
+- `youtubeVideoPlanningTool`
+- `youtubeKeywordResearchTool`
+- `youtubeVideoScriptGeneratorTool`
+
+例外的に、特定のアナリティクス機能については、より具体的な命名を使用します：
+- `getChannelAnalytics`
+- `getVideoAnalytics`
+- `getAudienceGeographics`
+
+### エージェント（Agents）
+
+エージェントには `youtube{機能名}Agent` の形式を使用します。
+
+**例:**
+- `youtubeTitleGeneratorAgent`
+- `youtubeAnalyticsAgent`
+- `youtubeInputCollectionAgent`
+- `youtubeChannelConceptAgent`
+- `youtubeThumbnailTitleGeneratorAgent`
+- `youtubeVideoPlanningAgent`
+- `youtubeKeywordResearchAgent`
+- `youtubeOrchestratorAgent`
+
+### ワークフロー（Workflows）
+
+ワークフローには `youtube{機能名}Workflow` の形式を使用します。
+
+**例:**
+- `youtubeTitleGeneratorWorkflow`
+- `youtubeChannelAnalyticsWorkflow`
+- `youtubeVideoAnalyticsWorkflow`
+- `youtubeInputCollectionWorkflow`
+- `youtubeChannelConceptWorkflow`
+- `youtubeThumbnailTitleGeneratorWorkflow`
+- `youtubeVideoPlanningWorkflow`
+- `youtubeKeywordResearchWorkflow`
+
+## テストファイルの命名規則
+
+テストファイルについては、テスト対象のコンポーネントに対応した命名を使用します。
+
+**例:**
+- `youtube-search.test.ts`: `youtubeSearchTool` のテスト
+- `title-generator.test.ts`: `youtubeTitleGeneratorTool` のテスト
+- `input-collection.test.ts`: `youtubeInputCollectionTool`, `youtubeInputCollectionAgent`, `youtubeInputCollectionWorkflow` のテスト
+
+E2Eテストファイルは、`.e2e.test.ts` 拡張子を使用します。
+
+**例:**
+- `inputCollection.e2e.test.ts`
+- `titleGenerator.e2e.test.ts`
+- `videoPlanning.e2e.test.ts`
+
+## モック化のガイドライン
+
+テスト内でコンポーネントをモック化する際は、以下のガイドラインに従います：
+
+1. 適切な命名規則を保持する
+2. 一貫したインターフェースを維持する
+3. 適切なインポート/エクスポートパターンを使用する
+
+**例:**
+```typescript
+// 正しいモック化の例
+jest.mock('../src/mastra/tools/titleGenerator', () => ({
+  youtubeTitleGeneratorTool: {
+    id: 'youtube-title-generator',
+    description: 'Generate engaging YouTube thumbnail text and titles based on video content',
+    execute: mockExecute
+  }
+}));
+
+import { youtubeTitleGeneratorTool } from '../src/mastra/tools/titleGenerator';
+```
+
+## 結論
+
+一貫した命名規則を採用することで、コードの可読性、保守性、および新規開発者のオンボーディングを改善します。このガイドラインに従って、コンポーネントの命名および関連する参照を更新してください。

--- a/atami/docs/refactoring-summary.md
+++ b/atami/docs/refactoring-summary.md
@@ -1,0 +1,61 @@
+# リファクタリング概要：命名規則の統一
+
+## 概要
+
+このリファクタリングでは、YouTube Mastraプロジェクト全体の命名規則を統一しました。主な目的は、コードの可読性と保守性を向上させ、新規開発者のオンボーディングを容易にすることです。
+
+## 変更点
+
+### 1. テストファイルの更新
+
+以下のテストファイルを更新し、一貫した命名規則を適用しました：
+
+- `title-generator.test.ts`
+  - `youtubeTitleGeneratorTool` の命名規則に合わせてモックとインポートを更新
+  - テスト説明を最新の機能に合わせて更新（サムネイルテキスト生成機能の追加）
+  - モックデータの構造を最新の実装に合わせて更新
+
+- `input-collection.test.ts`
+  - `inputCollectionAgent` → `youtubeInputCollectionAgent` に変更
+  - `inputCollectionWorkflow` → `youtubeInputCollectionWorkflow` に変更
+
+- `tests/e2e/inputCollection.e2e.test.ts`
+  - `inputCollectionWorkflow` → `youtubeInputCollectionWorkflow` に変更（実行部分）
+
+### 2. ドキュメント作成
+
+命名規則を明確にするために、以下のドキュメントを作成しました：
+
+- `docs/naming-conventions.md`: プロジェクト全体の命名規則ガイドライン
+  - コンポーネントタイプ別の命名パターン
+  - 例外的なケースの説明
+  - モック化のガイドライン
+
+### 3. 問題解決
+
+以下の問題を特定し解決しました：
+
+- テストのタイムアウト問題
+  - Jest のモック実装の問題を特定し修正
+  - `mockExecute` 関数を使用した適切なモック化手法の適用
+
+## 命名規則の要約
+
+プロジェクト全体で採用されている命名規則は以下の通りです：
+
+1. **ツール**: `youtube{機能名}Tool`
+   - 例: `youtubeTitleGeneratorTool`, `youtubeSearchTool`
+
+2. **エージェント**: `youtube{機能名}Agent`
+   - 例: `youtubeTitleGeneratorAgent`, `youtubeInputCollectionAgent`
+
+3. **ワークフロー**: `youtube{機能名}Workflow`
+   - 例: `youtubeTitleGeneratorWorkflow`, `youtubeInputCollectionWorkflow`
+
+詳細な命名規則ガイドラインは `docs/naming-conventions.md` を参照してください。
+
+## 今後の課題
+
+1. 残りのテストファイルについても、命名規則の統一を進める
+2. 依存関係のモック化手法を統一し、テストの安定性を向上させる
+3. 例外的な命名のコンポーネント（アナリティクス関連等）の扱いについて検討する

--- a/atami/tests/e2e/inputCollection.e2e.test.ts
+++ b/atami/tests/e2e/inputCollection.e2e.test.ts
@@ -1,7 +1,7 @@
 /**
- * 入力収集ワークフローのE2Eテスト
+ * Input Collection Workflow E2E Test
  */
-import { inputCollectionWorkflow } from '../../src/mastra/workflows/inputCollectionWorkflow';
+import { youtubeInputCollectionWorkflow } from '../../src/mastra/workflows/inputCollectionWorkflow';
 import { waitForWorkflowCompletion, mockInputs } from './setup';
 
 describe('入力収集ワークフロー E2Eテスト', () => {
@@ -22,7 +22,7 @@ describe('入力収集ワークフロー E2Eテスト', () => {
     
     // ワークフローを実行
     const result = await waitForWorkflowCompletion(
-      inputCollectionWorkflow.run(input)
+      youtubeInputCollectionWorkflow.run(input)
     );
     
     // 結果の検証
@@ -65,7 +65,7 @@ describe('入力収集ワークフロー E2Eテスト', () => {
     
     // ワークフローを実行
     const result = await waitForWorkflowCompletion(
-      inputCollectionWorkflow.run(input)
+      youtubeInputCollectionWorkflow.run(input)
     );
     
     // 結果の検証
@@ -92,7 +92,7 @@ describe('入力収集ワークフロー E2Eテスト', () => {
     
     // ワークフローを実行
     const result = await waitForWorkflowCompletion(
-      inputCollectionWorkflow.run(input)
+      youtubeInputCollectionWorkflow.run(input)
     );
     
     // エラー結果の検証

--- a/atami/tests/input-collection.test.ts
+++ b/atami/tests/input-collection.test.ts
@@ -32,7 +32,7 @@ jest.mock('../src/mastra/tools/inputCollection', () => ({
 
 // エージェントとワークフローをモック化
 jest.mock('../src/mastra/agents/inputCollectionAgent', () => ({
-  inputCollectionAgent: {
+  youtubeInputCollectionAgent: {
     name: 'YouTube Input Collection Agent',
     instructions: 'Test instructions'
   }
@@ -54,7 +54,7 @@ jest.mock('../src/mastra/workflows/inputCollectionWorkflow', () => {
   });
   
   return {
-    inputCollectionWorkflow: {
+    youtubeInputCollectionWorkflow: {
       id: 'youtube-input-collection-workflow',
       name: 'YouTube Input Collection Workflow',
       description: 'Collect initial input for YouTube channel operation',
@@ -64,8 +64,8 @@ jest.mock('../src/mastra/workflows/inputCollectionWorkflow', () => {
 });
 
 import { youtubeInputCollectionTool } from '../src/mastra/tools/inputCollection';
-import { inputCollectionAgent } from '../src/mastra/agents/inputCollectionAgent';
-import { inputCollectionWorkflow } from '../src/mastra/workflows/inputCollectionWorkflow';
+import { youtubeInputCollectionAgent } from '../src/mastra/agents/inputCollectionAgent';
+import { youtubeInputCollectionWorkflow } from '../src/mastra/workflows/inputCollectionWorkflow';
 
 describe('YouTube Input Collection Tests', () => {
   // 各テスト前にモックをリセット
@@ -144,24 +144,24 @@ describe('YouTube Input Collection Tests', () => {
   });
 
   // エージェント（Agent）のテスト
-  describe('inputCollectionAgent', () => {
+  describe('youtubeInputCollectionAgent', () => {
     it('should be defined', () => {
-      expect(inputCollectionAgent).toBeDefined();
-      expect(inputCollectionAgent.name).toBe('YouTube Input Collection Agent');
+      expect(youtubeInputCollectionAgent).toBeDefined();
+      expect(youtubeInputCollectionAgent.name).toBe('YouTube Input Collection Agent');
     });
   });
 
   // ワークフロー（Workflow）のテスト
-  describe('inputCollectionWorkflow', () => {
+  describe('youtubeInputCollectionWorkflow', () => {
     it('should be defined', () => {
-      expect(inputCollectionWorkflow).toBeDefined();
-      expect(inputCollectionWorkflow.id).toBe('youtube-input-collection-workflow');
-      expect(inputCollectionWorkflow.name).toBe('YouTube Input Collection Workflow');
+      expect(youtubeInputCollectionWorkflow).toBeDefined();
+      expect(youtubeInputCollectionWorkflow.id).toBe('youtube-input-collection-workflow');
+      expect(youtubeInputCollectionWorkflow.name).toBe('YouTube Input Collection Workflow');
     });
 
     it('should run successfully', async () => {
       // ワークフローを実行
-      const result = await inputCollectionWorkflow.run({
+      const result = await youtubeInputCollectionWorkflow.run({
         businessName: 'テスト事業者',
         presenterName: 'テスト演者',
         youtubeGoal: '認知拡大',


### PR DESCRIPTION
## Summary
- 追加のテストファイルを更新し、一貫した命名規則を適用（input-collection.test.ts, e2e/inputCollection.e2e.test.ts）
- 命名規則に関するドキュメントを追加（docs/naming-conventions.md）
- リファクタリングの概要ドキュメントを追加（docs/refactoring-summary.md）

## 命名規則の基本原則
1. YouTubeに関連するすべてのコンポーネントには `youtube` プレフィックスを使用
2. コンポーネントのタイプを示すサフィックスを使用（例: `Agent`, `Tool`, `Workflow`）
3. 機能を明確に表す名前を使用し、略語は避ける

## テスト計画
- 変更されたテストが正常に実行されることを確認
- 命名規則が今後の開発でも一貫して適用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)